### PR TITLE
Increase RSA key size to 4096 bits to support larger config

### DIFF
--- a/web/scripts/generate-keys.ts
+++ b/web/scripts/generate-keys.ts
@@ -10,7 +10,7 @@ if (!fs.existsSync(KEYS_DIR)) {
 
 function generateKeyPair() {
   return crypto.generateKeyPairSync('rsa', {
-    modulusLength: 2048,
+    modulusLength: 4096,
     publicKeyEncoding: {
       type: 'spki',
       format: 'pem',


### PR DESCRIPTION
The previous 2048-bit RSA keys caused decryption failures when encrypting large configuration payloads (e.g., Google AI API keys did not fit, preferences) due to the "data too large for modulus" error.

This commit updates the key generation script to produce 4096-bit RSA keys, increasing the maximum encrypted payload size and ensuring stability when signing up or saving config data.

No other changes to the encryption logic were necessary.

